### PR TITLE
Modernize the code a bit for current Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ use positioned_io::ReadAt;
 use qcow2::Qcow2;
 
 // Open a qcow2 file.
-let file = try!(File::open("image.qcow2"));
-let qcow = try!(Qcow2::open(file));
+let file = File::open("image.qcow2")?;
+let qcow = Qcow2::open(file)?;
 
 // Read some data from the middle.
-let reader = try!(qcow.reader());
+let reader = qcow.reader()?;
 let mut buf = vec![0, 4096];
-try!(reader.read_exact_at(5 * 1024 * 1024, &mut buf));
+reader.read_exact_at(5 * 1024 * 1024, &mut buf)?;
 ```
 
 ### Documentation

--- a/src/bin/qcow2-dump.rs
+++ b/src/bin/qcow2-dump.rs
@@ -1,5 +1,5 @@
 extern crate qcow2;
-use std::io::Write;
+
 
 trait OrDie<T> {
     fn or_die(self, msg: &str, path: &str) -> T;
@@ -9,7 +9,7 @@ impl<T, E: std::fmt::Display> OrDie<T> for Result<T, E> {
         match self {
             Ok(t) => t,
             Err(e) => {
-                writeln!(std::io::stderr(), "{} `{}': {}", msg, path, e).unwrap();
+                eprintln!("{} `{}': {}", msg, path, e);
                 std::process::exit(1);
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,18 +42,6 @@ impl<T> From<PoisonError<T>> for Error {
 }
 
 impl StdError for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref err) => err.description(),
-            Error::FileType => "Not a qcow2 file",
-            Error::Version(_) => "Unsupported version",
-            Error::UnsupportedFeature(_) => "Unsupported feature",
-            Error::FileFormat(_) => "Malformed qcow2 file",
-            Error::Internal(_) => "Internal error",
-            Error::Poison(ref s) => s,
-        }
-    }
-
     fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             Error::Io(ref err) => Some(err),
@@ -66,11 +54,12 @@ impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
             Error::Io(ref err) => err.fmt(f),
+            Error::FileType => f.write_str("Not a qcow2 file"),
             Error::Version(found) => write!(f, "Unsupported version {}", found),
             Error::UnsupportedFeature(ref feat) => write!(f, "Unsupported feature: {}", feat),
             Error::FileFormat(ref err) => write!(f, "Malformed qcow2 file: {}", err),
             Error::Internal(ref err) => write!(f, "Internal error: {}", err),
-            _ => f.write_str(self.description()),
+            Error::Poison(ref s) => f.write_str(s),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,7 +54,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             Error::Io(ref err) => Some(err),
             _ => None,

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,4 +1,3 @@
-use std::ascii::AsciiExt;
 use std::borrow::Cow;
 use std::fmt::{self, Debug, Formatter};
 use std::io::ErrorKind;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -36,7 +36,7 @@ impl Extension for UnknownExtension {
         self.code
     }
     fn read(&mut self, io: &mut dyn ReadInt) -> Result<()> {
-        try!(io.read_to_end(&mut self.data));
+        io.read_to_end(&mut self.data)?;
         Ok(())
     }
 }
@@ -82,14 +82,14 @@ impl Extension for FeatureNameTable {
                             .to_owned()));
                     }
 
-                    let bit = try!(io.read_u8());
+                    let bit = io.read_u8()?;
                     if bit > 63 {
                         return Err(Error::FileFormat("bit number too high in feature name table"
                             .to_owned()));
                     }
 
                     let mut buf = [0; 46];
-                    try!(io.read_exact(&mut buf));
+                    io.read_exact(&mut buf)?;
                     // Remove trailing zero bytes from name.
                     let chars = buf.iter()
                         .take_while(|&&c| c != 0).copied()

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -20,8 +20,8 @@ impl Feature {
     pub fn new(kind: FeatureKind, names: &'static [&'static str]) -> Self {
         Feature {
             bits: 0,
-            kind: kind,
-            names: names,
+            kind,
+            names,
         }
     }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -50,9 +50,9 @@ const COMPATIBLE_LAZY_REFCOUNTS: u64 = 0b1;
 #[allow(dead_code)]
 const AUTOCLEAR_BITMAPS: u64 = 0b1;
 
-static INCOMPATIBLE_NAMES: &'static [&'static str] = &["dirty", "corrupt"];
-static COMPATIBLE_NAMES: &'static [&'static str] = &["lazy refcounts"];
-static AUTOCLEAR_NAMES: &'static [&'static str] = &["bitmaps"];
+static INCOMPATIBLE_NAMES: &[&str] = &["dirty", "corrupt"];
+static COMPATIBLE_NAMES: &[&str] = &["lazy refcounts"];
+static AUTOCLEAR_NAMES: &[&str] = &["bitmaps"];
 
 const HEADER_LENGTH_V3: usize = 104;
 
@@ -71,7 +71,7 @@ pub struct HeaderV3 {
 }
 impl HeaderV3 {
     // Get an extension by extension code. If we can't find one, use UnknownExtension.
-    pub fn extension(&mut self, code: u32) -> &mut Extension {
+    pub fn extension(&mut self, code: u32) -> &mut dyn Extension {
         match code {
             extension::EXT_CODE_FEATURE_NAME_TABLE => &mut self.feature_name_table,
             _ => {
@@ -204,7 +204,7 @@ impl Header {
             {
                 let take = io.take(len);
                 let mut sub = ByteIo::<_, BigEndian>::new(take);
-                let mut ext = self.v3.extension(ext_code);
+                let ext = self.v3.extension(ext_code);
                 try!(ext.read(&mut sub));
 
                 // Verify all is read.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ impl<I> Qcow2<I>
         let io: ByteIo<_, BigEndian> = ByteIo::new(io);
         let mut q = Qcow2 {
             header: Default::default(),
-            io: io,
+            io,
             l2_cache: Mutex::new(LruCache::new(L2_CACHE_SIZE)),
         };
         try!(q.header.read(&mut q.io));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,13 +75,13 @@ const L2_CACHE_SIZE: usize = 32;
 /// # fn foo() -> qcow2::Result<()> {
 ///
 /// // Open a file.
-/// let file = try!(File::open("image.qcow2"));
-/// let qcow = try!(Qcow2::open(file));
+/// let file = File::open("image.qcow2")?;
+/// let qcow = Qcow2::open(file)?;
 ///
 /// // Read some data.
-/// let reader = try!(qcow.reader());
+/// let reader = qcow.reader()?;
 /// let mut buf = vec![0, 4096];
-/// try!(reader.read_exact_at(5 * 1024 * 1024, &mut buf));
+/// reader.read_exact_at(5 * 1024 * 1024, &mut buf)?;
 ///
 /// # Ok(()) } fn main() { foo().unwrap(); }
 /// ```
@@ -110,7 +110,7 @@ impl<I> Qcow2<I>
             io,
             l2_cache: Mutex::new(LruCache::new(L2_CACHE_SIZE)),
         };
-        try!(q.header.read(&mut q.io));
+        q.header.read(&mut q.io)?;
         Ok(q)
     }
 


### PR DESCRIPTION
This is a fairly conservative subset that just removes warnings during the compilation on the latest Rust.