### PR TITLE
Use the Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "qcow2"
 version = "0.1.2"
+edition = "2021"
 authors = ["Dave Vasilevsky <dave@vasilevsky.ca>"]
 description = "Reading qcow2 virtual disk images"
 keywords = ["qcow2", "qemu", "disk", "image"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@ mod feature;
 mod header;
 mod int;
 mod read;
-pub use error::Error;
-pub use read::Reader;
+pub use crate::error::Error;
+pub use crate::read::Reader;
 
 use std::fmt::{self, Debug, Formatter};
 use std::result;


### PR DESCRIPTION
I also worked on updating dependencies, but not yet solved because there were a lot of changes in how `positioned_io` works.

This PR could be merged as is, though.